### PR TITLE
Don't import all of RxJS, only Observable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 // import libraries
 import * as Request from 'request';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 
 // internals object for private methods and attributes
 const internals = {};


### PR DESCRIPTION
Best I can tell, this lib does not use any operators and only uses the Observable class itself. So instead of importing all of RxJS, it should probably only import Observable itself.

Since this is almost certainly used in Node.js, most people will prolly end up importing all of RxJS anyway _but_ some people won't--Electron apps where `require()` IO is a bottleneck sometimes don't.