### PR TITLE
Upgrade to rxjs@5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/njl07/rx-http-request#readme",
   "dependencies": {
     "request": "^2.75.0",
-    "rxjs": "^5.0.0-beta.12"
+    "rxjs": "^5.0.3"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.16.0",


### PR DESCRIPTION
We had very few breaking changes between beta.12 and now, and none of them should impact only creating custom Observables like this lib does.